### PR TITLE
[HOTFIX] Swagger 접속을 위한 Spring Security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13'
 
-	// Redis
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/umc/valuedi/global/config/SecurityConfig.java
+++ b/src/main/java/org/umc/valuedi/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package org.umc.valuedi.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final String[] allowUris = {
+            // Swagger & API Docs
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+
+            // Health Check & Monitoring
+            "/actuator/health",
+
+            // Public Auth APIs (로그아웃 제외)
+            "/auth/oauth/kakao/**",
+            "/auth/login",
+            "/auth/check-username",
+            "/auth/token/refresh",
+            "/auth/signup",
+            "/auth/email/**",
+            "/auth/status",
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers(allowUris).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #18 

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
Swagger 접속을 위해 Spring Security를 설정했습니다.
- build.grade에 Spring Security 의존성 추가
- Swagger 관련 주소 접속 허용

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [ ] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [x] 설정 또는 인프라 관련 변경
- [ ] 리팩토링

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
Swagger 접속을 위해 JWT 및 다른 기능들은 제외하고 SecurityConfig만 먼저 올립니다!
다른 기능들은 [기존 PR](https://github.com/Valuedi/Valuedi_Backend/pull/14)에서 확인해주세요!

## 📸 API Test Results (Swagger)
<!-- API 테스트 스크린샷 첨부 -->
<img width="1325" height="713" alt="스크린샷 2026-01-15 오후 10 27 24" src="https://github.com/user-attachments/assets/763ce258-99b4-4810-bad1-4bb4a0bf36a9" />


## ✅ Checklist
- [x] API 테스트 완료
- [x] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)