### PR TITLE
[REFACTOR/#84] Trophy 기능 접근시 유저 정보 주입하도록 수정

### DIFF
--- a/src/main/java/org/umc/valuedi/domain/trophy/controller/TrophyController.java
+++ b/src/main/java/org/umc/valuedi/domain/trophy/controller/TrophyController.java
@@ -8,6 +8,7 @@ import org.umc.valuedi.domain.trophy.enums.PeriodType;
 import org.umc.valuedi.domain.trophy.service.query.TrophyQueryService;
 import org.umc.valuedi.global.apiPayload.ApiResponse;
 import org.umc.valuedi.global.apiPayload.code.GeneralSuccessCode;
+import org.umc.valuedi.global.security.annotation.CurrentMember;
 
 import java.util.List;
 
@@ -27,12 +28,9 @@ public class TrophyController implements TrophyControllerDocs{
     @GetMapping("/members/me/trophies")
     public ApiResponse<List<TrophyResponse>> getMyTrophies(
             @RequestParam(name = "periodType", defaultValue = "MONTHLY") PeriodType periodType,
-            @RequestParam(name = "periodKey") String periodKey
-//            @AuthenticationPrincipal CustomUserDetails userDetails
+            @RequestParam(name = "periodKey") String periodKey,
+            @CurrentMember Long memberId
     ) {
-//        Long memberId = Long.parseLong(userDetails.getUsername());
-        Long memberId = 1L;
-
         List<TrophyResponse> response = trophyQueryService.getMyTrophies(memberId, periodType, periodKey);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
     }

--- a/src/main/java/org/umc/valuedi/domain/trophy/controller/TrophyControllerDocs.java
+++ b/src/main/java/org/umc/valuedi/domain/trophy/controller/TrophyControllerDocs.java
@@ -9,6 +9,7 @@ import org.umc.valuedi.domain.trophy.dto.response.TrophyMetaResponse;
 import org.umc.valuedi.domain.trophy.dto.response.TrophyResponse;
 import org.umc.valuedi.domain.trophy.enums.PeriodType;
 import org.umc.valuedi.global.apiPayload.ApiResponse;
+import org.umc.valuedi.global.security.annotation.CurrentMember;
 
 import java.util.List;
 
@@ -23,11 +24,9 @@ public interface TrophyControllerDocs {
             @Parameter(description = "조회 기간 타입 (DAILY, MONTHLY, LAST_30_DAYS)", example = "MONTHLY")
             @RequestParam(name = "periodType", defaultValue = "MONTHLY") PeriodType periodType,
 
-            @Parameter(description = "조회 기간 키 (예: '2023-10', '2023-10-27')", example = "2023-10")
-            @RequestParam(name = "periodKey") String periodKey
+            @Parameter(description = "조회 기간 키 (예: '2025-12', '2025-12-27')", example = "2025-12")
+            @RequestParam(name = "periodKey") String periodKey,
 
-            // 로그인 기능 완성되면 활성화
-//            @Parameter(hidden = true)
-//            @AuthenticationPrincipal CustomUserDetails userDetails
+            @CurrentMember Long memberId
             );
 }


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #84 

## 📝 Summary
트로피 조회 API 접근 시 하드코딩된 사용자 ID를 제거하고, @CurrentMember 어노테이션을 사용해 인증된 사용자 ID가 자동 주입되도록 개선

## 🔄 Changes
- [x] API 변경 (추가/수정)
- [x] 리팩토링

## 📸 API Test Results (Swagger)
<img width="707" height="732" alt="image" src="https://github.com/user-attachments/assets/5026e337-5159-497d-9701-56feb7147bb1" />
<img width="1345" height="519" alt="image" src="https://github.com/user-attachments/assets/6beb8cfa-d300-4a54-be91-be63ab1cb014" />


## ✅ Checklist
- [x] API 테스트 완료
- [x] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)