### PR TITLE
[FIX] 제미나이 재시도 백오프 간격 조정으로 타임아웃 개선

### DIFF
--- a/src/main/java/org/umc/valuedi/global/external/genai/client/GeminiClient.java
+++ b/src/main/java/org/umc/valuedi/global/external/genai/client/GeminiClient.java
@@ -26,7 +26,7 @@ public class GeminiClient {
     private static final Duration PER_ATTEMPT_TIMEOUT = Duration.ofSeconds(30);  // 시도별 제한
     private static final Duration OVERALL_DEADLINE = Duration.ofSeconds(240);  // 전체 제한
 
-    private static final long BASE_BACKOFF_MILLIS = 200;
+    private static final long BASE_BACKOFF_MILLIS = 2_000;
     private static final long MAX_BACKOFF_MILLIS = 90_000;
 
     private static final ExecutorService executor =
@@ -153,7 +153,7 @@ public class GeminiClient {
 
     private void sleepBackoff(int attempt, Throwable cause) {
         // attempt=1 실패 후 -> 2초, attempt=2 실패 후 -> 4초, attempt=3 -> 8초 ...
-        long exp = 1L << attempt; // 1=>2, 2=>4, 3=>8 ...
+        long exp = 1L << (attempt - 1); // 1=>1, 2=>2, 3=>4 ...
         long backoff = BASE_BACKOFF_MILLIS * exp;
 
         // cap


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #96 

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
서버 타임아웃 대응으로 Gemini 재시도 지수 백오프(2→4→8… 최대 60~90초)를 추가

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [ ] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [x] 리팩토링

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

## 📸 API Test Results (Swagger)
<!-- API 테스트 스크린샷 첨부 -->

## ✅ Checklist
- [x] API 테스트 완료
- [ ] 테스트 결과 사진 첨부
- [ ] 빌드 성공 확인 (./gradlew build)