### PR TITLE
[REFACTOR/#101] 리프레시 토큰 및 state 인증 시 쿠키 기반으로 롤백

### DIFF
--- a/src/main/java/org/umc/valuedi/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/org/umc/valuedi/domain/auth/converter/AuthConverter.java
@@ -12,11 +12,6 @@ import java.time.LocalDate;
 
 public class AuthConverter {
 
-    // 카카오 로그인 URL과 state 값을 하나의 DTO로 변환
-    public static AuthResDTO.LoginUrlDTO toLoginUrlDTO(String loginUrl, String state) {
-        return new AuthResDTO.LoginUrlDTO(loginUrl, state);
-    }
-
     // 로컬 회원가입 정보 바탕으로 Member 엔티티 생성
     public static Member toGeneralMember(AuthReqDTO.RegisterReqDTO dto, String encodedPassword) {
         return Member.builder()

--- a/src/main/java/org/umc/valuedi/domain/auth/dto/res/AuthResDTO.java
+++ b/src/main/java/org/umc/valuedi/domain/auth/dto/res/AuthResDTO.java
@@ -8,7 +8,11 @@ public class AuthResDTO {
     @Builder
     public record LoginResultDTO (
             String accessToken,
+
+            // 리프레시 토큰은 쿠키로 전달하고 JSON body에는 저장하지 않음
+            @JsonIgnore
             String refreshToken,
+
             Long memberId
     ) {}
 
@@ -21,11 +25,5 @@ public class AuthResDTO {
     public record AuthStatusDTO (
             Boolean isLogin,
             Long memberId
-    ) {}
-
-    @Builder
-    public record LoginUrlDTO(
-            String url,
-            String state
     ) {}
 }

--- a/src/main/java/org/umc/valuedi/global/config/SecurityConfig.java
+++ b/src/main/java/org/umc/valuedi/global/config/SecurityConfig.java
@@ -95,7 +95,10 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedOrigins(Arrays.asList(
+                "https://valuedi-web.vercel.app",
+                "http://localhost:5173"
+        ));
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));

--- a/src/main/java/org/umc/valuedi/global/security/util/CookieUtil.java
+++ b/src/main/java/org/umc/valuedi/global/security/util/CookieUtil.java
@@ -11,10 +11,10 @@ public class CookieUtil {
     public void addCookie(HttpServletResponse response, String name, String value, int maxAge, String path) {
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
-                .secure(false) // 개발 서버 테스트를 위해 임시로 HTTP 허용. 실제 배포 시에는 true로 변경
+                .secure(true)
                 .path(path)
                 .maxAge(maxAge)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #101 

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
이전에 작업했던 쿠키 기반 인증 방식을 되돌리고, CORS 설정에 프론트엔드 배포 주소를 추가하였습니다.
- 쿠키 기반 인증 방식
  - 로그인 시 리프레시 토큰은 JSON Body가 아닌 쿠키로 생성하도록 변경
  - 카카오 콜백 API 호출 시 state 값은 쿼리 파라미터가 아닌 쿠키에서 받아오도록 변경
  - 토큰 재발급 시 리프레시 토큰은 쿼리 파라미터가 아닌 쿠키에서 받아오도록 변경
- CORS 설정
  - 기존에는 와일드카드(`*`)로 모든 도메인을 허용했었으나, 프론트엔드 배포 주소(`https://valuedi-web.vercel.app/`)와 로컬 개발환경(`http://localhost:5173`)만 허용하도록 수정

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [ ] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [x] 리팩토링

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

## 📸 API Test Results (Swagger)
<!-- API 테스트 스크린샷 첨부 -->

## ✅ Checklist
- [x] API 테스트 완료
- [ ] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)