### PR TITLE
[FIX#107] AssetBalanceService 조회 로직 수정

### DIFF
--- a/src/main/java/org/umc/valuedi/domain/asset/dto/res/AssetResDTO.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/dto/res/AssetResDTO.java
@@ -1,13 +1,12 @@
 package org.umc.valuedi.domain.asset.dto.res;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Schema(description = "자산 통합 응답 DTO")
 public class AssetResDTO {
@@ -30,6 +29,7 @@ public class AssetResDTO {
 
     @Getter
     @AllArgsConstructor
+    @NoArgsConstructor // Map 초기화를 위해 기본 생성자 추가
     @Builder
     @Schema(description = "AssetFetchService의 내부 처리 결과 DTO (API 응답으로 직접 사용되지 않음)")
     public static class AssetSyncResult {
@@ -50,5 +50,21 @@ public class AssetResDTO {
 
         @Schema(description = "가계부 동기화에 사용될 조회 종료일")
         private LocalDate toDate;
+
+        @Builder.Default
+        @Schema(description = "계좌 ID별 최신 잔액 맵")
+        private Map<Long, Long> latestBalances = new HashMap<>();
+
+        public boolean hasLatestBalanceFor(Long accountId) {
+            return latestBalances != null && latestBalances.containsKey(accountId);
+        }
+
+        public Long getLatestBalanceFor(Long accountId) {
+            return latestBalances.get(accountId);
+        }
+
+        public void addLatestBalance(Long accountId, Long balance) {
+            this.latestBalances.put(accountId, balance);
+        }
     }
 }

--- a/src/main/java/org/umc/valuedi/domain/asset/service/AssetBalanceService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/AssetBalanceService.java
@@ -38,7 +38,7 @@ public class AssetBalanceService {
 
             // 1. 동기화 결과 DTO에 방금 수집한 실시간 잔액이 있다면 DB 조회 없이 즉시 반환 (레이스 컨디션 방지)
             if (result.hasLatestBalanceFor(accountId)) {
-                log.info("[AssetBalanceService] 실시간 동기화 데이터 사용. AccountID: {}, Balance: {}", accountId, result.getLatestBalanceFor(accountId));
+                log.info("[AssetBalanceService] 실시간 동기화 데이터 사용. AccountID: {}", accountId);
                 return result.getLatestBalanceFor(accountId);
             }
 


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #107 

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
동기화 작업 시 발생하는 DB 중복 조회를 방지하고 실시간으로 파싱된 잔액 데이터를 즉시 반환하도록 개선

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [x] API 변경 (추가/수정)
  - AssetResDTO.AssetSyncResult에 실시간 계좌 잔액 정보를 담는 latestBalances 필드 추가
- [x] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
  - AssetFetchService: API 수집 데이터에서 계좌별 최신 잔액을 추출하여 DB 조회 없이 DTO로 전달하는 로직 구현
  - AssetBalanceService: 동기화 결과에 잔액 정보가 포함된 경우 bankTransactionRepository 조회를 생략하고 즉시 반환하도록 수정
- [ ] 설정 또는 인프라 관련 변경
- [x] 리팩토링
  - AssetSyncProcessor: 비동기 동기화 프로세스 내에서 AssetFetchService의 변경된 반환 타입을 적용

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
레이스 컨디션 방지: 동기화 직후 DB 반영 지연으로 인해 이전 잔액이 조회되는 문제를 방지하기 위해 메모리 내 데이터를 우선 사용하도록 했습니다. 이 접근 방식이 서비스의 다른 도메인과 일관성이 있는지, 그냥 사용해도 괜찮은지 체크 부탁드립니다.

예외 처리: AssetBalanceService에서 동기화 실패 시 fallback으로 기존 db값 사용하게 처리했는데 코드가 적절한지 체크 부탁드리겠습니다.

API 테스트는 따로 진행하지 않았습니다.

## ✅ Checklist
- [ ] API 테스트 완료
- [ ] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)