### PR TITLE
[REFACTOR/#111] 금융 mbti 검사와 추천 생성 로직 분리

### DIFF
--- a/src/main/java/org/umc/valuedi/domain/mbti/service/FinanceMbtiService.java
+++ b/src/main/java/org/umc/valuedi/domain/mbti/service/FinanceMbtiService.java
@@ -1,7 +1,6 @@
 package org.umc.valuedi.domain.mbti.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.mbti.converter.FinanceMbtiTestConverter;
@@ -13,13 +12,11 @@ import org.umc.valuedi.domain.mbti.repository.MbtiQuestionRepository;
 import org.umc.valuedi.domain.mbti.validator.FinanceMbtiTestValidator;
 import org.umc.valuedi.domain.member.entity.Member;
 import org.umc.valuedi.domain.member.repository.MemberRepository;
-import org.umc.valuedi.domain.savings.service.RecommendationService;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -31,7 +28,6 @@ public class FinanceMbtiService {
     private final FinanceMbtiScoringService scoringService;
     private final FinanceMbtiTestValidator financeMbtiTestValidator;
     private final FinanceMbtiTestConverter financeMbtiTestConverter;
-    private final RecommendationService recommendationService;
 
     public MemberMbtiTest submitTest(Long memberId, FinanceMbtiTestRequestDto req) {
 
@@ -52,15 +48,6 @@ public class FinanceMbtiService {
         FinanceMbtiScoringService.ScoreResult score = scoringService.score(activeQuestions, answersByQuestionId);
         MemberMbtiTest test = financeMbtiTestConverter.toEntity(member, req, score, activeQuestionMap);
 
-        MemberMbtiTest savedTest = memberMbtiTestRepository.save(test);
-
-        try {
-            recommendationService.generateAndSaveRecommendations(memberId);
-            log.info("[Recommend] MBTI 검사 후 자동 추천 생성 성공. memberId={}", memberId);
-        } catch (Exception e) {
-            // 제미나이 호출이 실패해도 MBTI 저장은 유지되도록 예외를 삼키고 로그만 남김
-            log.error("[Recommend] MBTI 저장에는 성공했으나, 자동 추천 생성 중 오류 발생. memberId={}: {}", memberId, e.getMessage());
-        }
-        return savedTest;
+        return memberMbtiTestRepository.save(test);
     }
 }

--- a/src/main/java/org/umc/valuedi/domain/savings/controller/RecommendationControllerDocs.java
+++ b/src/main/java/org/umc/valuedi/domain/savings/controller/RecommendationControllerDocs.java
@@ -16,11 +16,11 @@ import org.umc.valuedi.global.security.annotation.CurrentMember;
 public interface RecommendationControllerDocs {
 
     @Operation(
-            summary = "[개발/수동 갱신용] 적금 추천 생성 API",
+            summary = "적금 추천 생성 API",
             description = """
-                    **주의: 일반적인 서비스 흐름에서는 MBTI 검사 완료 시 서버 내부에서 자동 호출됩니다.**
-                    
-                    - 로그인 사용자(JWT)의 현재 MBTI를 바탕으로 Gemini 추천을 생성하고 DB를 갱신합니다.
+                    로그인 사용자(JWT)의 현재 MBTI를 바탕으로 Gemini 추천을 생성하고 DB를 갱신합니다.
+                    MBTI 검사 완료 후 이 API를 호출하여 맞춤 추천을 받을 수 있습니다.
+
                     - 응답 속도는 Gemini API 호출을 포함하므로 약 3~7초 정도 소요될 수 있습니다
                     """,
             responses = {


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #111

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
- MBTI 검사 로직에서 Gemini 호출 제거
- 추천 생성 API에서만 Gemini 호출하도록 구조 변경

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [X] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [ ] 리팩토링

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

## 📸 API Test Results (Swagger)
<!-- API 테스트 스크린샷 첨부 -->

## ✅ Checklist
- [x] API 테스트 완료
- [ ] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)