### PR TITLE
[FIX/#113] Finance MBTI 테스트 데드락 개선 및 트랜잭션 범위 재조정

### DIFF
--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetFetchService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetFetchService.java
@@ -34,7 +34,7 @@ public class AssetFetchService {
 
         // 각 기관별로 비동기 API 호출 실행
         List<CompletableFuture<AssetFetchWorker.FetchResult>> futures = connections.stream()
-                .map(connection -> assetFetchWorker.fetchAndConvertData(connection, member))
+                .map(connection -> assetFetchWorker.fetchAndConvertData(connection.getId(), member))
                 .toList();
 
         // 모든 비동기 작업이 완료될 때까지 대기하고 결과 취합

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetFetchService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetFetchService.java
@@ -1,26 +1,17 @@
 package org.umc.valuedi.domain.asset.service.command;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.asset.dto.res.AssetResDTO;
-import org.umc.valuedi.domain.asset.entity.BankAccount;
 import org.umc.valuedi.domain.asset.entity.BankTransaction;
-import org.umc.valuedi.domain.asset.entity.Card;
 import org.umc.valuedi.domain.asset.entity.CardApproval;
-import org.umc.valuedi.domain.asset.repository.bank.bankAccount.BankAccountRepository;
-import org.umc.valuedi.domain.asset.repository.bank.bankTransaction.BankTransactionRepository;
-import org.umc.valuedi.domain.asset.repository.card.cardApproval.CardApprovalRepository;
 import org.umc.valuedi.domain.asset.service.command.worker.AssetFetchWorker;
 import org.umc.valuedi.domain.connection.entity.CodefConnection;
 import org.umc.valuedi.domain.connection.repository.CodefConnectionRepository;
 import org.umc.valuedi.domain.member.entity.Member;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -30,17 +21,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AssetFetchService {
 
-    private final EntityManager entityManager;
     private final CodefConnectionRepository codefConnectionRepository;
-    private final BankTransactionRepository bankTransactionRepository;
-    private final CardApprovalRepository cardApprovalRepository;
-    private final BankAccountRepository bankAccountRepository;
     private final AssetFetchWorker assetFetchWorker;
+    private final AssetPersistService assetPersistService;
 
-    private record BankTransactionKey(LocalDateTime trDatetime, Long inAmount, Long outAmount, String desc3) {}
-    private record CardApprovalKey(Card card, String approvalNo) {}
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    /**
+     * 외부 API 호출 + DB 저장을 분리하여 커넥션 풀 점유 최소화
+     */
     public AssetResDTO.AssetSyncResult fetchAndSaveLatestData(Member member) {
         List<CodefConnection> connections = codefConnectionRepository.findByMemberIdWithMember(member.getId());
         LocalDate today = LocalDate.now();
@@ -80,17 +67,16 @@ public class AssetFetchService {
 
         // 새로운 데이터 필터링 및 저장
         int totalNewBankTransactions = 0;
+        int totalNewCardApprovals = 0;
+
+        if (!allFetchedBankTransactions.isEmpty() || !allFetchedCardApprovals.isEmpty()) {
+            AssetPersistService.SaveResult saveResult = assetPersistService.saveNewAssetData(allFetchedBankTransactions, allFetchedCardApprovals);
+            totalNewBankTransactions = saveResult.newBankTransactionCount();
+            totalNewCardApprovals = saveResult.newCardApprovalCount();
+        }
+
+        // 실시간 잔액 추출
         if (!allFetchedBankTransactions.isEmpty()) {
-            List<BankTransaction> newBankTransactions = filterNewBankTransactions(allFetchedBankTransactions);
-            if (!newBankTransactions.isEmpty()) {
-                bankTransactionRepository.bulkInsert(newBankTransactions);
-                totalNewBankTransactions = newBankTransactions.size();
-
-                // 계좌 잔액 업데이트 (기존 엔티티 반영)
-                updateAccountBalances(newBankTransactions);
-            }
-
-            // 수집된 모든 거래내역 중 계좌별 가장 최신 잔액을 추출하여 실시간 데이터 맵에 저장
             allFetchedBankTransactions.stream()
                     .collect(Collectors.groupingBy(tx -> tx.getBankAccount().getId(),
                             Collectors.maxBy(Comparator.comparing(BankTransaction::getTrDatetime))))
@@ -101,19 +87,6 @@ public class AssetFetchService {
                     }));
         }
 
-        int totalNewCardApprovals = 0;
-        if (!allFetchedCardApprovals.isEmpty()) {
-            List<CardApproval> newCardApprovals = filterNewCardApprovals(allFetchedCardApprovals);
-            if (!newCardApprovals.isEmpty()) {
-                cardApprovalRepository.bulkInsert(newCardApprovals);
-                totalNewCardApprovals = newCardApprovals.size();
-            }
-        }
-
-        // JdbcTemplate 사용 후 영속성 컨텍스트 초기화
-        entityManager.flush();
-        entityManager.clear();
-
         return AssetResDTO.AssetSyncResult.builder()
                 .newBankTransactionCount(totalNewBankTransactions)
                 .newCardApprovalCount(totalNewCardApprovals)
@@ -123,61 +96,5 @@ public class AssetFetchService {
                 .toDate(today)
                 .latestBalances(realTimeBalances) // 실시간 잔액 데이터 전달
                 .build();
-    }
-
-    private void updateAccountBalances(List<BankTransaction> transactions) {
-        Map<BankAccount, BankTransaction> latestTransactions = transactions.stream()
-                .collect(Collectors.groupingBy(BankTransaction::getBankAccount,
-                        Collectors.collectingAndThen(
-                                Collectors.maxBy(Comparator.comparing(BankTransaction::getTrDatetime)),
-                                Optional::get
-                        )));
-
-        List<BankAccount> updatedAccounts = new ArrayList<>();
-
-        latestTransactions.forEach((account, latestTransaction) -> {
-            if (latestTransaction.getAfterBalance() != null) {
-                account.updateBalance(latestTransaction.getAfterBalance());
-                updatedAccounts.add(account);
-            }
-        });
-
-        if (!updatedAccounts.isEmpty()) {
-            bankAccountRepository.saveAll(updatedAccounts);
-        }
-    }
-
-    private List<BankTransaction> filterNewBankTransactions(List<BankTransaction> allFetched) {
-        if (allFetched.isEmpty()) return List.of();
-
-        LocalDate minDate = allFetched.stream().map(BankTransaction::getTrDate).min(LocalDate::compareTo).orElse(LocalDate.now());
-        List<BankAccount> accounts = allFetched.stream().map(BankTransaction::getBankAccount).distinct().toList();
-
-        List<BankTransaction> existingTransactions = bankTransactionRepository.findByBankAccountInAndTrDatetimeAfter(accounts, minDate.atStartOfDay());
-
-        Set<BankTransactionKey> existingKeys = existingTransactions.stream()
-                .map(tx -> new BankTransactionKey(tx.getTrDatetime(), tx.getInAmount(), tx.getOutAmount(), Objects.toString(tx.getDesc3(), "")))
-                .collect(Collectors.toSet());
-
-        return allFetched.stream()
-                .filter(tx -> !existingKeys.contains(new BankTransactionKey(tx.getTrDatetime(), tx.getInAmount(), tx.getOutAmount(), Objects.toString(tx.getDesc3(), ""))))
-                .toList();
-    }
-
-    private List<CardApproval> filterNewCardApprovals(List<CardApproval> allFetched) {
-        if (allFetched.isEmpty()) return List.of();
-
-        List<Card> cards = allFetched.stream().map(CardApproval::getCard).distinct().toList();
-        List<String> approvalNos = allFetched.stream().map(CardApproval::getApprovalNo).distinct().toList();
-
-        List<CardApproval> existingApprovals = cardApprovalRepository.findByCardInAndApprovalNoIn(cards, approvalNos);
-
-        Set<CardApprovalKey> existingKeys = existingApprovals.stream()
-                .map(ca -> new CardApprovalKey(ca.getCard(), ca.getApprovalNo()))
-                .collect(Collectors.toSet());
-
-        return allFetched.stream()
-                .filter(ca -> !existingKeys.contains(new CardApprovalKey(ca.getCard(), ca.getApprovalNo())))
-                .toList();
     }
 }

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetPersistService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetPersistService.java
@@ -1,0 +1,124 @@
+package org.umc.valuedi.domain.asset.service.command;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.valuedi.domain.asset.entity.BankAccount;
+import org.umc.valuedi.domain.asset.entity.BankTransaction;
+import org.umc.valuedi.domain.asset.entity.Card;
+import org.umc.valuedi.domain.asset.entity.CardApproval;
+import org.umc.valuedi.domain.asset.repository.bank.bankAccount.BankAccountRepository;
+import org.umc.valuedi.domain.asset.repository.bank.bankTransaction.BankTransactionRepository;
+import org.umc.valuedi.domain.asset.repository.card.cardApproval.CardApprovalRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 자산 데이터 DB 저장 전용 서비스.
+ * AssetFetchService의 self-invocation 문제를 해결하기 위해 분리.
+ */
+@Service
+@RequiredArgsConstructor
+public class AssetPersistService {
+
+    private final EntityManager entityManager;
+    private final BankTransactionRepository bankTransactionRepository;
+    private final CardApprovalRepository cardApprovalRepository;
+    private final BankAccountRepository bankAccountRepository;
+
+    private record BankTransactionKey(LocalDateTime trDatetime, Long inAmount, Long outAmount, String desc3) {}
+    private record CardApprovalKey(Card card, String approvalNo) {}
+
+    public record SaveResult(int newBankTransactionCount, int newCardApprovalCount) {}
+
+    /**
+     * 새로운 자산 데이터를 짧은 트랜잭션에서 필터링 및 저장
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public SaveResult saveNewAssetData(List<BankTransaction> allFetchedBankTransactions, List<CardApproval> allFetchedCardApprovals) {
+        int totalNewBankTransactions = 0;
+        if (!allFetchedBankTransactions.isEmpty()) {
+            List<BankTransaction> newBankTransactions = filterNewBankTransactions(allFetchedBankTransactions);
+            if (!newBankTransactions.isEmpty()) {
+                bankTransactionRepository.bulkInsert(newBankTransactions);
+                totalNewBankTransactions = newBankTransactions.size();
+                updateAccountBalances(newBankTransactions);
+            }
+        }
+
+        int totalNewCardApprovals = 0;
+        if (!allFetchedCardApprovals.isEmpty()) {
+            List<CardApproval> newCardApprovals = filterNewCardApprovals(allFetchedCardApprovals);
+            if (!newCardApprovals.isEmpty()) {
+                cardApprovalRepository.bulkInsert(newCardApprovals);
+                totalNewCardApprovals = newCardApprovals.size();
+            }
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+
+        return new SaveResult(totalNewBankTransactions, totalNewCardApprovals);
+    }
+
+    private void updateAccountBalances(List<BankTransaction> transactions) {
+        Map<BankAccount, BankTransaction> latestTransactions = transactions.stream()
+                .collect(Collectors.groupingBy(BankTransaction::getBankAccount,
+                        Collectors.collectingAndThen(
+                                Collectors.maxBy(Comparator.comparing(BankTransaction::getTrDatetime)),
+                                Optional::get
+                        )));
+
+        List<BankAccount> updatedAccounts = new ArrayList<>();
+
+        latestTransactions.forEach((account, latestTransaction) -> {
+            if (latestTransaction.getAfterBalance() != null) {
+                account.updateBalance(latestTransaction.getAfterBalance());
+                updatedAccounts.add(account);
+            }
+        });
+
+        if (!updatedAccounts.isEmpty()) {
+            bankAccountRepository.saveAll(updatedAccounts);
+        }
+    }
+
+    private List<BankTransaction> filterNewBankTransactions(List<BankTransaction> allFetched) {
+        if (allFetched.isEmpty()) return List.of();
+
+        LocalDate minDate = allFetched.stream().map(BankTransaction::getTrDate).min(LocalDate::compareTo).orElse(LocalDate.now());
+        List<BankAccount> accounts = allFetched.stream().map(BankTransaction::getBankAccount).distinct().toList();
+
+        List<BankTransaction> existingTransactions = bankTransactionRepository.findByBankAccountInAndTrDatetimeAfter(accounts, minDate.atStartOfDay());
+
+        Set<BankTransactionKey> existingKeys = existingTransactions.stream()
+                .map(tx -> new BankTransactionKey(tx.getTrDatetime(), tx.getInAmount(), tx.getOutAmount(), Objects.toString(tx.getDesc3(), "")))
+                .collect(Collectors.toSet());
+
+        return allFetched.stream()
+                .filter(tx -> !existingKeys.contains(new BankTransactionKey(tx.getTrDatetime(), tx.getInAmount(), tx.getOutAmount(), Objects.toString(tx.getDesc3(), ""))))
+                .toList();
+    }
+
+    private List<CardApproval> filterNewCardApprovals(List<CardApproval> allFetched) {
+        if (allFetched.isEmpty()) return List.of();
+
+        List<Card> cards = allFetched.stream().map(CardApproval::getCard).distinct().toList();
+        List<String> approvalNos = allFetched.stream().map(CardApproval::getApprovalNo).distinct().toList();
+
+        List<CardApproval> existingApprovals = cardApprovalRepository.findByCardInAndApprovalNoIn(cards, approvalNos);
+
+        Set<CardApprovalKey> existingKeys = existingApprovals.stream()
+                .map(ca -> new CardApprovalKey(ca.getCard(), ca.getApprovalNo()))
+                .collect(Collectors.toSet());
+
+        return allFetched.stream()
+                .filter(ca -> !existingKeys.contains(new CardApprovalKey(ca.getCard(), ca.getApprovalNo())))
+                .toList();
+    }
+}

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncProcessor.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncProcessor.java
@@ -27,7 +27,7 @@ public class AssetSyncProcessor {
     /**
      * 실제 동기화 로직을 수행하는 비동기 메서드
      */
-    @Async("assetFetchExecutor")
+    @Async("assetSyncExecutor")
     public void runSyncProcess(Long memberId, Long logId) {
         log.info("자산 동기화 백그라운드 작업을 시작합니다. 회원 ID: {}", memberId);
         try {

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncProcessor.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncProcessor.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.asset.dto.res.AssetResDTO;
 import org.umc.valuedi.domain.connection.service.command.SyncLogCommandService;
 import org.umc.valuedi.domain.ledger.service.command.LedgerSyncService;
@@ -29,7 +28,6 @@ public class AssetSyncProcessor {
      * 실제 동기화 로직을 수행하는 비동기 메서드
      */
     @Async("assetFetchExecutor")
-    @Transactional
     public void runSyncProcess(Long memberId, Long logId) {
         log.info("자산 동기화 백그라운드 작업을 시작합니다. 회원 ID: {}", memberId);
         try {
@@ -49,9 +47,9 @@ public class AssetSyncProcessor {
             }
 
             // 트랜잭션 3: 동기화 로그 및 최종 시간 업데이트
-            member.updateLastSyncedAt();
+            ledgerSyncService.updateMemberLastSyncedAt(memberId);
             syncLogCommandService.updateToSuccess(logId);
-            log.info("자산 동기화 백그라운드 작업을 성공적으로 완료했습니다. 회원 ID: {}", member.getId());
+            log.info("자산 동기화 백그라운드 작업을 성공적으로 완료했습니다. 회원 ID: {}", memberId);
 
         } catch (Exception e) {
             // 실패 로그 기록

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncService.java
@@ -126,6 +126,7 @@ public class AssetSyncService {
         // 기존 syncTransactions 대신 rebuildLedger 호출
         // 범위: 최근 3개월 (기존 정책 유지)
         ledgerSyncService.rebuildLedger(member, LocalDate.now().minusMonths(DEFAULT_SYNC_PERIOD_MONTHS), LocalDate.now());
+        member.updateLastSyncedAt();
     }
 
     /**

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncService.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/AssetSyncService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.asset.entity.BankAccount;
 import org.umc.valuedi.domain.asset.entity.BankTransaction;
 import org.umc.valuedi.domain.asset.entity.Card;
@@ -26,7 +25,6 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class AssetSyncService {
 
     private static final int DEFAULT_SYNC_PERIOD_MONTHS = 3;
@@ -126,7 +124,7 @@ public class AssetSyncService {
         // 기존 syncTransactions 대신 rebuildLedger 호출
         // 범위: 최근 3개월 (기존 정책 유지)
         ledgerSyncService.rebuildLedger(member, LocalDate.now().minusMonths(DEFAULT_SYNC_PERIOD_MONTHS), LocalDate.now());
-        member.updateLastSyncedAt();
+        ledgerSyncService.updateMemberLastSyncedAt(member.getId());
     }
 
     /**

--- a/src/main/java/org/umc/valuedi/domain/asset/service/command/worker/AssetFetchWorker.java
+++ b/src/main/java/org/umc/valuedi/domain/asset/service/command/worker/AssetFetchWorker.java
@@ -104,7 +104,6 @@ public class AssetFetchWorker {
                             return existingCards.stream()
                                     .filter(oldCard -> oldCard.getCardNoMasked().equals(newCard.getCardNoMasked()))
                                     .findFirst()
-                                    .map(oldCard -> oldCard) // 정보 갱신 필요 시 여기서 수행
                                     .orElse(newCard);
                         }).toList();
 

--- a/src/main/java/org/umc/valuedi/domain/connection/repository/CodefConnectionRepository.java
+++ b/src/main/java/org/umc/valuedi/domain/connection/repository/CodefConnectionRepository.java
@@ -14,6 +14,9 @@ public interface CodefConnectionRepository extends JpaRepository<CodefConnection
     @Query("SELECT c FROM CodefConnection c JOIN FETCH c.member WHERE c.id = :id")
     Optional<CodefConnection> findByIdWithMember(@Param("id") Long id);
 
+    @Query("SELECT c FROM CodefConnection c JOIN FETCH c.member LEFT JOIN FETCH c.bankAccountList WHERE c.id = :id")
+    Optional<CodefConnection> findByIdWithAccountsAndMember(@Param("id") Long id);
+
     @Query("SELECT c FROM CodefConnection c JOIN FETCH c.member WHERE c.member.id = :memberId")
     List<CodefConnection> findByMemberIdWithMember(@Param("memberId") Long memberId);
 

--- a/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionCommandService.java
+++ b/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionCommandService.java
@@ -6,11 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.connection.dto.req.ConnectionReqDTO;
 import org.umc.valuedi.domain.connection.entity.CodefConnection;
-import org.umc.valuedi.domain.connection.enums.BusinessType;
 import org.umc.valuedi.domain.connection.exception.ConnectionException;
 import org.umc.valuedi.domain.connection.exception.code.ConnectionErrorCode;
 import org.umc.valuedi.domain.connection.repository.CodefConnectionRepository;
-import org.umc.valuedi.domain.goal.repository.GoalRepository;
 import org.umc.valuedi.domain.member.entity.Member;
 import org.umc.valuedi.domain.member.exception.MemberException;
 import org.umc.valuedi.domain.member.exception.code.MemberErrorCode;
@@ -20,17 +18,17 @@ import org.umc.valuedi.global.external.codef.service.CodefAccountService;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ConnectionCommandService {
 
     private final CodefAccountService codefAccountService;
     private final CodefConnectionRepository codefConnectionRepository;
-    private final GoalRepository goalRepository;
+    private final ConnectionDeleteCommandService connectionDeleteCommandService;
     private final MemberRepository memberRepository;
 
     /**
      * 금융사 계정 연동
      */
+    @Transactional
     public void connect(Long memberId, ConnectionReqDTO.Connect request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
@@ -42,6 +40,7 @@ public class ConnectionCommandService {
      * 금융사 연동 해제
      */
     public void disconnect(Long memberId, Long connectionId) {
+        // 조회 및 권한 검증 (트랜잭션 없음)
         CodefConnection connection = codefConnectionRepository.findByIdWithMember(connectionId)
                 .orElseThrow(() -> new ConnectionException(ConnectionErrorCode.CONNECTION_NOT_FOUND));
 
@@ -49,18 +48,14 @@ public class ConnectionCommandService {
             throw new ConnectionException(ConnectionErrorCode.CONNECTION_ACCESS_DENIED);
         }
 
+        // 외부 API 호출 (트랜잭션 밖 — 락 보유하지 않음)
         codefAccountService.deleteAccount(
                 connection.getConnectedId(),
                 connection.getOrganization(),
                 connection.getBusinessType()
         );
 
-        //하위 계좌/카드도 Soft Delete
-        codefConnectionRepository.delete(connection);
-
-        if (connection.getBusinessType() == BusinessType.BK) {
-            // 은행 계좌와 연결된 목표 Soft Delete 처리 (서브쿼리 사용)
-            goalRepository.softDeleteGoalsByConnectionId(connection.getId());
-        }
+        // DB 삭제 (짧은 트랜잭션)
+        connectionDeleteCommandService.deleteConnectionData(connectionId, connection.getBusinessType());
     }
 }

--- a/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionCommandService.java
+++ b/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionCommandService.java
@@ -3,9 +3,9 @@ package org.umc.valuedi.domain.connection.service.command;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.umc.valuedi.domain.connection.dto.req.ConnectionReqDTO;
 import org.umc.valuedi.domain.connection.entity.CodefConnection;
+import org.umc.valuedi.domain.connection.enums.BusinessType;
 import org.umc.valuedi.domain.connection.exception.ConnectionException;
 import org.umc.valuedi.domain.connection.exception.code.ConnectionErrorCode;
 import org.umc.valuedi.domain.connection.repository.CodefConnectionRepository;
@@ -28,11 +28,11 @@ public class ConnectionCommandService {
     /**
      * 금융사 계정 연동
      */
-    @Transactional
     public void connect(Long memberId, ConnectionReqDTO.Connect request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-        codefAccountService.connectAccount(member, request);
+        String existingConnectedId = codefAccountService.findExistingConnectedId(memberId);
+        String targetConnectedId = codefAccountService.callCodefConnectApi(existingConnectedId, request);
+
+        codefAccountService.saveConnection(memberId, targetConnectedId, request.getOrganization(), request.getBusinessTypeEnum());
         log.info("금융사 연동 완료 - memberId: {}, organization: {}", memberId, request.getOrganization());
     }
 

--- a/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionDeleteCommandService.java
+++ b/src/main/java/org/umc/valuedi/domain/connection/service/command/ConnectionDeleteCommandService.java
@@ -1,0 +1,35 @@
+package org.umc.valuedi.domain.connection.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.umc.valuedi.domain.connection.entity.CodefConnection;
+import org.umc.valuedi.domain.connection.enums.BusinessType;
+import org.umc.valuedi.domain.connection.exception.ConnectionException;
+import org.umc.valuedi.domain.connection.exception.code.ConnectionErrorCode;
+import org.umc.valuedi.domain.connection.repository.CodefConnectionRepository;
+import org.umc.valuedi.domain.goal.repository.GoalRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ConnectionDeleteCommandService {
+
+    private final CodefConnectionRepository codefConnectionRepository;
+    private final GoalRepository goalRepository;
+
+    /**
+     * CodefConnection 및 관련 데이터를 짧은 트랜잭션에서 소프트 딜리트한다.
+     * detached entity 문제 방지를 위해 connectionId로 재조회 후 삭제한다.
+     */
+    @Transactional
+    public void deleteConnectionData(Long connectionId, BusinessType businessType) {
+        CodefConnection connection = codefConnectionRepository.findById(connectionId)
+                .orElseThrow(() -> new ConnectionException(ConnectionErrorCode.CONNECTION_NOT_FOUND));
+
+        if (businessType == BusinessType.BK) {
+            goalRepository.softDeleteGoalsByConnectionId(connectionId);
+        }
+        // 하위 계좌/카드도 Soft Delete (Cascade)
+        codefConnectionRepository.delete(connection);
+    }
+}

--- a/src/main/java/org/umc/valuedi/domain/connection/service/event/ConnectionEventListener.java
+++ b/src/main/java/org/umc/valuedi/domain/connection/service/event/ConnectionEventListener.java
@@ -16,7 +16,7 @@ public class ConnectionEventListener {
 
     private final AssetSyncService assetSyncService;
 
-    @Async("assetFetchExecutor")
+    @Async("assetSyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleConnectionSuccess(ConnectionSuccessEvent event) {
         log.info("금융사 연동 성공 이벤트 수신 - Connection ID: {}, Organization: {}",

--- a/src/main/java/org/umc/valuedi/domain/ledger/service/command/LedgerSyncService.java
+++ b/src/main/java/org/umc/valuedi/domain/ledger/service/command/LedgerSyncService.java
@@ -107,8 +107,6 @@ public class LedgerSyncService {
             ledgerEntryRepository.bulkInsert(entries);
             log.info("Ledger Rebuild Complete: Member {}, {} entries created.", member.getId(), entries.size());
         }
-
-        member.updateLastSyncedAt();
     }
 
     private LedgerEntry createFromCard(Member member, CardApproval ca, Category defaultCategory, String key) {

--- a/src/main/java/org/umc/valuedi/domain/savings/service/RecommendationService.java
+++ b/src/main/java/org/umc/valuedi/domain/savings/service/RecommendationService.java
@@ -18,7 +18,6 @@ import org.umc.valuedi.domain.savings.dto.response.SavingsResponseDTO;
 import org.umc.valuedi.domain.savings.entity.Recommendation;
 import org.umc.valuedi.domain.savings.entity.Savings;
 import org.umc.valuedi.domain.savings.entity.SavingsOption;
-import org.umc.valuedi.domain.savings.enums.RecommendationStatus;
 import org.umc.valuedi.domain.savings.exception.SavingsException;
 import org.umc.valuedi.domain.savings.exception.code.SavingsErrorCode;
 import org.umc.valuedi.domain.savings.repository.RecommendationRepository;
@@ -53,7 +52,6 @@ public class RecommendationService {
 
     private final RecommendationTxService recommendationTxService;
 
-    @Transactional
     public SavingsResponseDTO.SavingsListResponse generateAndSaveRecommendations(Long memberId) {
         // 금융 mbti 최신 결과 조회
         MemberMbtiTest memberMbtiTest = memberMbtiTestRepository.findCurrentActiveTest(memberId)

--- a/src/main/java/org/umc/valuedi/global/config/AsyncConfig.java
+++ b/src/main/java/org/umc/valuedi/global/config/AsyncConfig.java
@@ -23,12 +23,23 @@ public class AsyncConfig {
         return executor;
     }
 
+    @Bean(name = "assetSyncExecutor")
+    public Executor assetSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("AssetSync-");
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "assetFetchExecutor")
     public Executor assetFetchExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);   // 기본 스레드 수 - 동시에 처리할 작업 수 (CPU 코어 수에 맞게 조절)
-        executor.setMaxPoolSize(10);   // 최대 스레드 수
-        executor.setQueueCapacity(100); // 큐 용량
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(3);
+        executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("AssetFetch-");
         executor.initialize();
         return executor;

--- a/src/main/java/org/umc/valuedi/global/external/codef/config/CodefFeignConfig.java
+++ b/src/main/java/org/umc/valuedi/global/external/codef/config/CodefFeignConfig.java
@@ -1,11 +1,13 @@
 package org.umc.valuedi.global.external.codef.config;
 
 import feign.Logger;
+import feign.Request;
 import feign.RequestInterceptor;
 import feign.codec.Decoder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.umc.valuedi.global.external.codef.service.CodefTokenService;
+
+import java.util.concurrent.TimeUnit;
 
 public class CodefFeignConfig {
 
@@ -22,5 +24,14 @@ public class CodefFeignConfig {
     @Bean
     public Decoder codefDecoder() {
         return new CodefResponseDecoder();
+    }
+
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(
+                10, TimeUnit.SECONDS,
+                5, TimeUnit.MINUTES,
+                true
+        );
     }
 }

--- a/src/main/java/org/umc/valuedi/global/external/codef/config/CodefFeignConfig.java
+++ b/src/main/java/org/umc/valuedi/global/external/codef/config/CodefFeignConfig.java
@@ -30,7 +30,7 @@ public class CodefFeignConfig {
     public Request.Options options() {
         return new Request.Options(
                 10, TimeUnit.SECONDS,
-                5, TimeUnit.MINUTES,
+                3, TimeUnit.MINUTES,
                 true
         );
     }

--- a/src/main/java/org/umc/valuedi/global/external/codef/service/CodefAccountService.java
+++ b/src/main/java/org/umc/valuedi/global/external/codef/service/CodefAccountService.java
@@ -39,7 +39,6 @@ public class CodefAccountService {
      */
     public String findExistingConnectedId(Long memberId) {
         return codefConnectionRepository.findByMemberId(memberId).stream()
-                .filter(c -> c.getStatus() != ConnectionStatus.DELETED)
                 .map(CodefConnection::getConnectedId)
                 .filter(Objects::nonNull)
                 .distinct()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,10 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
+  hikari:
+    maximum-pool-size: 30
+    leak-detection-threshold: 5000 # 커넥션 점유 메서드 파악
+
 codef:
   client-id: ${CODEF_CLIENT_ID}
   client-secret: ${CODEF_CLIENT_SECRET}


### PR DESCRIPTION
## 🔗 Related Issue
<!-- 이슈 번호를 작성하여 종료시켜주세요 -->
- Closes #113

## 📝 Summary
<!-- 작업한 기능을 설명해주세요 -->
- Lock wait timeout 데드락
  - 문제: 트랜잭션 내부에 외부 API 호출이 포함되어 DB 락 점유 시간이 길어지며 데드락 발생
  - 해결: 클래스 레벨 트랜잭션을 제거하고, 외부 API 호출과 DB 삭제 로직을 분리하여 트랜잭션 범위를 최소화함
- DB 커넥션 풀 고갈 
  - 문제: 중첩된 `@Transactional(REQUIRES_NEW)` 구조에서 API 응답을 기다리는 동안 인당 2개의 커넥션을 장시간 점유
  - 해결: `@Transactional` 범위를 재조정하고 DB 저장 전용 서비스(`AssetPersistService`)를 신설하여 커넥션 점유 시간을 단축
- 스레드풀 분리 및 Feign 타임아웃 설정
  - 문제: 부모와 자식 스레드가 같은 풀을 공유하여 서로의 실행을 막는 Thread Starvation 위험 발생
  - 해결: 레이어별 전용 스레드 풀을 신설하여 격리하고, Feign 클라이언트에 명시적인 타임아웃 설정을 적용해 무한 대기를 방지함

## 🔄 Changes
<!-- 구체적으로 어떤 파일/로직이 변경되었는지 체크해주세요 -->
- [ ] API 변경 (추가/수정)
- [ ] 데이터 및 도메인 변경 (DB, 비즈니스 로직)
- [ ] 설정 또는 인프라 관련 변경
- [X] 리팩토링

## 💬 Questions & Review Points
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

## 📸 API Test Results (Swagger)
<!-- API 테스트 스크린샷 첨부 -->

## ✅ Checklist
- [x] API 테스트 완료
- [ ] 테스트 결과 사진 첨부
- [x] 빌드 성공 확인 (./gradlew build)